### PR TITLE
Release v0.3.0: Wrapper mode and documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "safe-docker"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
-description = "Claude Code PreToolUse hook to prevent Docker bind mounts outside $HOME"
+description = "Safe Docker command wrapper and Claude Code hook for container security"
 license = "MIT OR Apache-2.0"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # safe-docker
 
-コーディングエージェント（Claude Code 等）に **安全に Docker 操作権限を渡す**ためのセキュリティツール。
+コーディングエージェントや開発者に **安全に Docker 操作権限を渡す**ためのセキュリティツール。
+
+2つの動作モードを持つ:
+
+- **Hook モード**: Claude Code PreToolUse hook として、エージェントの Docker コマンドを実行前に検証
+- **Wrapper モード**: `docker` コマンドの直接置換として、開発者のうっかりミスを防止
 
 ## 背景と目的
 
-コーディングエージェントに Docker を使わせると開発の自由度が大きく向上する一方、無制約な Docker 操作はホストシステムへの重大なリスクとなる。safe-docker は「使わせない」のではなく「安全に使わせる」ことを目指し、エージェントの Docker 操作に適切なガードレールを設ける。
+コーディングエージェントに Docker を使わせると開発の自由度が大きく向上する一方、無制約な Docker 操作はホストシステムへの重大なリスクとなる。safe-docker は「使わせない」のではなく「安全に使わせる」ことを目指し、Docker 操作に適切なガードレールを設ける。
 
 ### 守りたいもの
 
@@ -16,24 +21,38 @@
 ### 設計思想
 
 - **Fail-safe**: 判断できない場合はブロックまたはユーザー確認（deny / ask）
-- **透明性**: 拒否時は具体的な理由をエージェントにフィードバックし、自律的な修正を促す
+- **透明性**: 拒否時は具体的な理由をフィードバックし、自律的な修正を促す
 - **設定可能**: プロジェクトの要件に応じて許可範囲を調整可能
 - **低レイテンシ**: hook はユーザー体験に直結するため、全処理を 1ms 以下で完了
 
 ## アーキテクチャ
 
-二層構成で Docker 操作を保護する:
+### Hook モード（Claude Code 連携）
 
-1. **safe-docker** (Rust) — Claude Code PreToolUse hook。コマンド実行前に検証し、拒否理由をフィードバック
-2. **OPA Docker AuthZ** (Rego) — Docker デーモン認可プラグイン。全クライアントへの最終防衛線
+Claude Code PreToolUse hook として動作し、stdin/stdout の JSON プロトコルでコマンド実行前に検証する。
 
 ```
-[Claude Code] → [safe-docker hook] → [docker CLI] → [Docker daemon] → [OPA authz]
-                 UXレイヤー:                          強制レイヤー:
-                 拒否理由をエージェントに返す            全クライアントに適用
+[Claude Code] → [safe-docker hook] → [docker CLI] → [Docker daemon]
+                 stdin JSON で受信        ↑
+                 deny/ask/allow を返す     |
+                                    拒否理由をエージェントに返す
 ```
 
-safe-docker はエージェントに「なぜダメか」を伝えるUXレイヤーであり、OPA は設定ミスや hook 回避への最終防衛線となる。
+### Wrapper モード（docker 置換）
+
+`docker` コマンドの代わりに使用し、ポリシーチェック後に本物の docker を `exec` で実行する。
+
+```
+[ユーザー/スクリプト] → [safe-docker] → ポリシー評価 → [本物の docker]
+                         ↓                              ↑
+                    allow → exec で置換（プロセス数増加なし）
+                    deny  → stderr にエラー + exit 1
+                    ask   → 対話的確認 (y/N)
+```
+
+### OPA Docker AuthZ（Layer 2）
+
+OPA Docker AuthZ プラグインを最終防衛線として併用可能。safe-docker はエージェントに「なぜダメか」を伝える UX レイヤーであり、OPA は設定ミスや hook 回避への強制レイヤーとなる。
 
 ## 制限する操作
 
@@ -73,7 +92,7 @@ safe-docker はエージェントに「なぜダメか」を伝えるUXレイヤ
 | `--device` | ホストデバイスの直接マウント |
 | `--volumes-from` | 他コンテナからの危険なマウント継承 (ask) |
 
-### 3. シェル間接実行の検出
+### 3. シェル間接実行の検出（Hook モードのみ）
 
 直接の `docker` コマンド以外にも、シェル経由の間接実行を検出する。
 
@@ -110,6 +129,142 @@ safe-docker はエージェントに「なぜダメか」を伝えるUXレイヤ
 
 設定により、使用可能な Docker イメージを制限できる。
 
+## インストール
+
+### GitHub Releases からダウンロード（推奨）
+
+[Releases ページ](https://github.com/nekoruri/safe-docker/releases/latest) からプラットフォームに合ったバイナリをダウンロード:
+
+```bash
+# Linux (x86_64)
+curl -L https://github.com/nekoruri/safe-docker/releases/latest/download/safe-docker-x86_64-unknown-linux-gnu.tar.gz | tar xz
+cp safe-docker ~/.local/bin/
+
+# Linux (aarch64)
+curl -L https://github.com/nekoruri/safe-docker/releases/latest/download/safe-docker-aarch64-unknown-linux-gnu.tar.gz | tar xz
+cp safe-docker ~/.local/bin/
+
+# macOS (Apple Silicon)
+curl -L https://github.com/nekoruri/safe-docker/releases/latest/download/safe-docker-aarch64-apple-darwin.tar.gz | tar xz
+cp safe-docker ~/.local/bin/
+
+# macOS (Intel)
+curl -L https://github.com/nekoruri/safe-docker/releases/latest/download/safe-docker-x86_64-apple-darwin.tar.gz | tar xz
+cp safe-docker ~/.local/bin/
+```
+
+### ソースからビルド
+
+```bash
+cargo build --release
+cp target/release/safe-docker ~/.local/bin/
+```
+
+## セットアップ
+
+### Hook モード（Claude Code 連携）
+
+Claude Code の設定 (`~/.claude/settings.json`) に hook を登録:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "safe-docker"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Wrapper モード（docker 置換）
+
+#### 方法 1: 明示的に使用
+
+```bash
+safe-docker run -v ~/projects:/app ubuntu
+safe-docker compose up
+```
+
+#### 方法 2: シンボリックリンクで透過的に置換
+
+PATH の先頭に safe-docker を `docker` として配置することで、既存のスクリプトやワークフローをそのまま保護できる:
+
+```bash
+# ~/.local/bin が PATH の先頭にあることを確認
+ln -s $(which safe-docker) ~/.local/bin/docker
+
+# 以降、docker コマンドが safe-docker 経由で実行される
+docker run -v /etc:/data ubuntu
+# → [safe-docker] BLOCKED: Path is outside $HOME ...
+```
+
+safe-docker は `argv[0]` が `docker` の場合に透過モードとして動作し、本物の docker バイナリを自動検索して `exec` で置換する。
+
+#### 方法 3: シェルエイリアス
+
+```bash
+alias docker='safe-docker'
+```
+
+> **Note**: エイリアスは interactive シェルでのみ有効。スクリプト内では方法 2 のシンボリックリンクを推奨。
+
+## 使い方
+
+### Wrapper モード
+
+```bash
+# 基本: 通常の docker コマンドと同じ引数
+safe-docker run -v ~/projects:/app ubuntu echo hello
+safe-docker compose up -d
+safe-docker build -t myapp .
+
+# --dry-run: ポリシー判定のみ表示（docker を実行しない）
+safe-docker --dry-run run --privileged ubuntu
+# → [safe-docker] Decision: deny
+
+# --verbose: 拒否時に詳細な理由と対処法を表示
+safe-docker --verbose run --privileged ubuntu
+# → [safe-docker] BLOCKED: --privileged grants full host access ...
+# →   Tip: Check ~/.config/safe-docker/config.toml to adjust allowed paths or flags
+
+# --docker-path: docker バイナリパスを指定
+safe-docker --docker-path /usr/bin/docker run ubuntu
+```
+
+### Hook モード
+
+```bash
+# deny: $HOME 外マウント
+echo '{"tool_name":"Bash","tool_input":{"command":"docker run -v /etc:/data ubuntu"}}' | safe-docker
+
+# allow: $HOME 配下マウント
+echo '{"tool_name":"Bash","tool_input":{"command":"docker run -v ~/projects:/app ubuntu"}}' | safe-docker
+
+# ask: 機密パス
+echo '{"tool_name":"Bash","tool_input":{"command":"docker run -v ~/.ssh:/keys ubuntu"}}' | safe-docker
+
+# deny: --privileged
+echo '{"tool_name":"Bash","tool_input":{"command":"docker run --privileged ubuntu"}}' | safe-docker
+
+# allow: 非 docker コマンド (出力なし)
+echo '{"tool_name":"Bash","tool_input":{"command":"ls -la /tmp"}}' | safe-docker
+```
+
+### 設定チェック
+
+```bash
+safe-docker --check-config
+safe-docker --check-config --config /path/to/config.toml
+```
+
 ## 設定
 
 `~/.config/safe-docker/config.toml` (省略時はデフォルト値):
@@ -132,58 +287,41 @@ allowed_images = []
 
 # Docker ソケットマウントの禁止
 block_docker_socket = true
+
+# 監査ログ設定
+[audit]
+enabled = false
+format = "jsonl"       # "jsonl", "otlp", "both"
+jsonl_path = "~/.local/share/safe-docker/audit.jsonl"
+otlp_path = "~/.local/share/safe-docker/audit-otlp.jsonl"
+
+# ラッパーモード設定
+[wrapper]
+docker_path = ""              # 本物の docker バイナリパス (空=自動検出)
+non_interactive_ask = "deny"  # 非対話環境での ask 判定の扱い ("deny" / "allow")
 ```
 
-## インストール
+## 環境変数
 
-### GitHub Releases からダウンロード（推奨）
+| 変数 | 説明 |
+|------|------|
+| `SAFE_DOCKER_DOCKER_PATH` | 本物の docker バイナリパスを指定（設定ファイルより優先） |
+| `SAFE_DOCKER_ASK` | 非対話環境での ask 判定の扱い (`deny` / `allow`) |
+| `SAFE_DOCKER_BYPASS` | `1` に設定するとポリシーチェックをスキップ（escape hatch） |
+| `SAFE_DOCKER_ACTIVE` | 内部用: 再帰呼び出し防止。safe-docker が自動設定 |
+| `SAFE_DOCKER_AUDIT` | `1` に設定すると設定ファイルに関わらず監査ログを有効化 |
+| `SAFE_DOCKER_ENV` | 監査ログの `environment` フィールド（デフォルト: `development`） |
 
-[Releases ページ](https://github.com/nekoruri/safe-docker/releases/latest) からプラットフォームに合ったバイナリをダウンロード:
+## セキュリティモデル
 
-```bash
-# Linux (x86_64)
-curl -L https://github.com/nekoruri/safe-docker/releases/latest/download/safe-docker-v0.1.0-x86_64-unknown-linux-gnu.tar.gz | tar xz
-cp safe-docker-v0.1.0-x86_64-unknown-linux-gnu/safe-docker ~/.local/bin/
+| | Hook モード | Wrapper モード |
+|---|---|---|
+| 対象 | AI エージェント | 人間の開発者 |
+| 回避可能性 | 低（Claude Code が hook を迂回しにくい） | 高（`/usr/bin/docker` を直接呼べる） |
+| 目的 | **強制的な安全装置** | **うっかりミスの防止** |
+| Ask の意味 | Claude Code がユーザーに確認を促す | ユーザー自身に確認を求める |
 
-# Linux (aarch64)
-curl -L https://github.com/nekoruri/safe-docker/releases/latest/download/safe-docker-v0.1.0-aarch64-unknown-linux-gnu.tar.gz | tar xz
-cp safe-docker-v0.1.0-aarch64-unknown-linux-gnu/safe-docker ~/.local/bin/
-
-# macOS (Apple Silicon)
-curl -L https://github.com/nekoruri/safe-docker/releases/latest/download/safe-docker-v0.1.0-aarch64-apple-darwin.tar.gz | tar xz
-cp safe-docker-v0.1.0-aarch64-apple-darwin/safe-docker ~/.local/bin/
-
-# macOS (Intel)
-curl -L https://github.com/nekoruri/safe-docker/releases/latest/download/safe-docker-v0.1.0-x86_64-apple-darwin.tar.gz | tar xz
-cp safe-docker-v0.1.0-x86_64-apple-darwin/safe-docker ~/.local/bin/
-```
-
-### ソースからビルド
-
-```bash
-cargo build --release
-cp target/release/safe-docker ~/.local/bin/
-```
-
-Claude Code の設定 (`~/.claude/settings.json`) に hook を登録:
-
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "safe-docker"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
+Wrapper モードは「完全な強制」ではなく「安全ネット」。`SAFE_DOCKER_BYPASS=1` で意図的にスキップできるのは設計上正しい。完全な強制が必要な場合は OPA Docker AuthZ プラグイン等の別レイヤーで対応。
 
 ## テスト
 
@@ -196,28 +334,6 @@ cargo bench
 
 # 静的解析
 cargo clippy -- -D warnings
-```
-
-## 手動テスト
-
-```bash
-# deny: $HOME 外マウント
-echo '{"tool_name":"Bash","tool_input":{"command":"docker run -v /etc:/data ubuntu"}}' | safe-docker
-
-# allow: $HOME 配下マウント
-echo '{"tool_name":"Bash","tool_input":{"command":"docker run -v ~/projects:/app ubuntu"}}' | safe-docker
-
-# ask: 機密パス
-echo '{"tool_name":"Bash","tool_input":{"command":"docker run -v ~/.ssh:/keys ubuntu"}}' | safe-docker
-
-# deny: --privileged
-echo '{"tool_name":"Bash","tool_input":{"command":"docker run --privileged ubuntu"}}' | safe-docker
-
-# deny: シェル間接実行
-echo '{"tool_name":"Bash","tool_input":{"command":"eval \"docker run -v /etc:/data ubuntu\""}}' | safe-docker
-
-# allow: 非 docker コマンド (出力なし)
-echo '{"tool_name":"Bash","tool_input":{"command":"ls -la /tmp"}}' | safe-docker
 ```
 
 ## OPA Docker AuthZ (Layer 2)


### PR DESCRIPTION
## Summary
- Bump version 0.2.0 → 0.3.0
- Comprehensive README update documenting wrapper mode alongside existing hook mode
- Updated Cargo.toml description to reflect dual-mode tool

## README changes
- Added wrapper mode documentation (setup, usage, CLI options)
- Architecture diagrams for both Hook mode and Wrapper mode
- Three setup methods: explicit command, symlink, alias
- Environment variables reference table
- Security model comparison (Hook vs Wrapper)
- Configuration sections for `[audit]` and `[wrapper]`
- Reorganized into clearer "Setup" and "Usage" sections

## Test plan
- [x] All 334 tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo build` with new version succeeds
- [x] `--version` shows 0.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)