### PR TITLE
Detect container namespace sharing and mount propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ OPA Docker AuthZ プラグインを最終防衛線として併用可能。safe-d
 | `--ipc=host` | ホストの IPC 名前空間へのアクセス |
 | `--device` | ホストデバイスの直接マウント |
 | `--volumes-from` | 他コンテナからの危険なマウント継承 (ask) |
+| `--network=container:NAME` | 他コンテナのネットワーク名前空間への参加 |
+| `--pid=container:NAME` | 他コンテナのプロセス名前空間への参加 |
+| `--ipc=container:NAME` | 他コンテナの IPC 名前空間への参加 |
+| `-v ...:shared` / `bind-propagation=shared` | マウント変更がホストに伝搬 |
 
 ### 3. シェル間接実行の検出（Hook モードのみ）
 
@@ -291,7 +295,7 @@ safe-docker --check-config --config /path/to/config.toml
 allowed_paths = []
 
 # $HOME 配下で ask にする機密パス (ホームからの相対)
-sensitive_paths = [".ssh", ".aws", ".gnupg", ".docker", ".kube", ".config/gcloud", ".claude"]
+sensitive_paths = [".ssh", ".aws", ".gnupg", ".docker", ".kube", ".config/gcloud", ".claude", ".terraform", ".vault-token", ".config/gh", ".npmrc", ".pypirc"]
 
 # ブロックする危険フラグ
 blocked_flags = ["--privileged", "--pid=host", "--network=host"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,7 +64,7 @@ Docker デーモンの認可プラグイン。全 Docker クライアントに�
 | 項目 | 状態 | 理由 |
 |------|------|------|
 | **名前付きボリュームのドライバ** | 未検出 | CLI レベルでは `docker volume create --driver=local --opt device=/etc` を事前に実行されると検出不能 |
-| **bind propagation** | 未検出 | `:shared`, `:rshared` による伝播は追加リスクだがパース未対応 |
+| **bind propagation** | **検出済み (v0.4.0)** | `:shared`, `:rshared` は deny、`:slave` 等は許可 |
 | **`DOCKER_HOST` 環境変数** | パス検証のみ | リモート Docker ホストへの接続自体はブロックしない（コマンド内容は検証する） |
 
 ## Fail-safe 設計

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,93 @@
+# safe-docker ロードマップ
+
+このドキュメントはプロジェクトの長期タスクと進行状況を記録します。
+
+## リリース履歴
+
+| バージョン | 日付 | 主な変更 |
+|-----------|------|---------|
+| v0.1.0 | - | 初期リリース。Hook モード（Claude Code PreToolUse） |
+| v0.2.0 | - | セキュリティ強化（security-opt, namespace flags, docker cp/build パス検証, Compose 危険設定検出） |
+| v0.3.0 | 2026-02 | Wrapper モード追加（docker 置換、対話的確認、--dry-run、--verbose、監査ログ mode フィールド） |
+| v0.4.0 | 予定 | セキュリティ強化（コンテナ間 namespace 共有検出、mount propagation 検出、sensitive_paths 拡充）、Artifact Attestations 導入 |
+
+## 完了済みタスク
+
+### Phase 1: Hook モード (v0.1.0)
+- [x] stdin/stdout JSON プロトコル
+- [x] シェルコマンド分割（パイプ、チェイン、改行）
+- [x] Docker CLI 引数パース
+- [x] パス検証（$HOME 判定、パストラバーサル防止）
+- [x] ポリシー評価エンジン（deny/ask/allow）
+- [x] 設定ファイル（TOML）
+
+### Phase 2: セキュリティ強化 (v0.2.0)
+- [x] --security-opt 危険値検出（apparmor, seccomp, systempaths, no-new-privileges）
+- [x] 名前空間フラグ検出（--userns, --cgroupns, --ipc）
+- [x] docker cp / docker build のホストパス検証
+- [x] docker-compose.yml 危険設定検出（privileged, network_mode, pid, cap_add, security_opt, devices）
+- [x] docker exec --privileged 検出
+- [x] docker buildx build 対応
+- [x] 監査ログ（JSONL / OTLP）
+- [x] proptest によるファジング
+
+### Phase 3: Wrapper モード (v0.3.0)
+- [x] ラッパーモード基本動作（argv[0] 判定、docker exec、プロセス置換）
+- [x] 本物の docker バイナリ検索（設定 > 環境変数 > PATH 自動検索）
+- [x] 再帰呼び出し防止（SAFE_DOCKER_ACTIVE）
+- [x] --dry-run, --verbose, --help, --version, --docker-path オプション
+- [x] Ask の対話的確認（TTY 判定、非対話環境設定）
+- [x] 監査ログに mode フィールド追加
+- [x] コンテキスト固有の Tip メッセージ（generate_tips）
+- [x] エッジケーステスト充実
+
+### Phase 4: 配布とセキュリティ強化 (v0.4.0)
+- [x] GitHub Artifact Attestations（Sigstore ベース署名）
+- [x] SHA256 チェックサムファイル同梱
+- [x] docs/SUPPLY_CHAIN_SECURITY.md（エコシステム解説）
+- [x] README インストールセクション刷新（検証手順、cargo install）
+- [x] コンテナ間 namespace 共有検出（--network/--pid/--ipc=container:NAME）
+- [x] mount propagation 検出（shared/rshared → deny）
+- [x] sensitive_paths デフォルト拡充（.terraform, .vault-token, .config/gh, .npmrc, .pypirc）
+- [x] Compose の container:/service: namespace 参照検出
+
+## 未着手タスク
+
+### セキュリティ: 攻撃面の網羅的レビュー
+- [ ] 学術論文・CVE データベースとの突合によるギャップ分析
+- [ ] Docker API 直接呼び出し（REST API / SDK）の検出限界の文書化
+- [ ] BuildKit --secret / --ssh フラグの検証
+- [ ] --add-host / --dns によるネットワーク設定操作の検出
+- [ ] Compose `include:` ディレクティブ（外部ファイル参照）の対応
+- [ ] tmpfs サイズ制限なしの検出
+
+### 機能: ask レベル化
+- [ ] ask に deep/minor のレベルを導入
+- [ ] 非対話環境で minor ask のみ自動許可するオプション
+- [ ] CI/CD 環境で安全に SAFE_DOCKER_ASK=allow を使えるようにする
+
+### 機能: インストール体験の向上
+- [ ] Homebrew tap の作成
+- [ ] crates.io への公開（`cargo install safe-docker`）
+- [ ] シンボリックリンク setup ヘルパーコマンド
+
+### テスト
+- [ ] 多環境 smoke テスト（Linux glibc/musl, macOS Intel/Apple Silicon）
+- [ ] 複数 Docker デーモン環境テスト（colima, orbstack）
+- [ ] 大規模 compose ファイル（1000行超）のパフォーマンステスト
+
+### ドキュメント
+- [ ] is_flag_with_value() リスト更新ガイド
+- [ ] 新しい危険フラグ追加時のチェックリスト
+- [ ] OPA Docker AuthZ との統合ガイド
+
+## 設計メモ
+
+### セキュリティモデルの制限（既知・受容済み）
+
+以下はセキュリティツールとしての根本的な制限であり、OPA Docker AuthZ 等の別レイヤーで補完する:
+
+1. **スクリプトファイル経由のバイパス**: Write ツールでシェルスクリプトを作成し `bash script.sh` で実行された場合、script 内の docker コマンドは検査できない
+2. **Docker API 直接呼び出し**: curl や SDK でソケット/TCP 経由の API を直接叩かれると検出不能
+3. **複雑なシェル構文**: 関数定義内、case 文内、変数展開経由の docker コマンドは検出困難
+4. **Wrapper モードの迂回**: `/usr/bin/docker` を直接呼べば safe-docker をスキップできる（設計上の特性、「うっかりミス防止」が目的）

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -119,18 +119,28 @@ fn extract_service_dangerous_settings(service: &serde_yml::Value, flags: &mut Ve
         flags.push(DangerousFlag::Privileged);
     }
 
-    // network_mode: host
-    if let Some(mode) = service.get("network_mode").and_then(|v| v.as_str())
-        && mode == "host"
-    {
-        flags.push(DangerousFlag::NetworkHost);
+    // network_mode: host | container:NAME | service:NAME
+    if let Some(mode) = service.get("network_mode").and_then(|v| v.as_str()) {
+        if mode == "host" {
+            flags.push(DangerousFlag::NetworkHost);
+        } else if let Some(name) = mode
+            .strip_prefix("container:")
+            .or_else(|| mode.strip_prefix("service:"))
+        {
+            flags.push(DangerousFlag::NetworkContainer(name.to_string()));
+        }
     }
 
-    // pid: host
-    if let Some(pid) = service.get("pid").and_then(|v| v.as_str())
-        && pid == "host"
-    {
-        flags.push(DangerousFlag::PidHost);
+    // pid: host | container:NAME | service:NAME
+    if let Some(pid) = service.get("pid").and_then(|v| v.as_str()) {
+        if pid == "host" {
+            flags.push(DangerousFlag::PidHost);
+        } else if let Some(name) = pid
+            .strip_prefix("container:")
+            .or_else(|| pid.strip_prefix("service:"))
+        {
+            flags.push(DangerousFlag::PidContainer(name.to_string()));
+        }
     }
 
     // userns_mode: host
@@ -140,11 +150,16 @@ fn extract_service_dangerous_settings(service: &serde_yml::Value, flags: &mut Ve
         flags.push(DangerousFlag::UsernsHost);
     }
 
-    // ipc: host
-    if let Some(ipc) = service.get("ipc").and_then(|v| v.as_str())
-        && ipc == "host"
-    {
-        flags.push(DangerousFlag::IpcHost);
+    // ipc: host | container:NAME | service:NAME
+    if let Some(ipc) = service.get("ipc").and_then(|v| v.as_str()) {
+        if ipc == "host" {
+            flags.push(DangerousFlag::IpcHost);
+        } else if let Some(name) = ipc
+            .strip_prefix("container:")
+            .or_else(|| ipc.strip_prefix("service:"))
+        {
+            flags.push(DangerousFlag::IpcContainer(name.to_string()));
+        }
     }
 
     // cap_add: [SYS_ADMIN, ...]

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,6 +94,11 @@ fn default_sensitive_paths() -> Vec<String> {
         ".kube".to_string(),
         ".config/gcloud".to_string(),
         ".claude".to_string(),
+        ".terraform".to_string(),
+        ".vault-token".to_string(),
+        ".config/gh".to_string(),
+        ".npmrc".to_string(),
+        ".pypirc".to_string(),
     ]
 }
 

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -80,6 +80,30 @@ pub fn evaluate(cmd: &DockerCommand, config: &Config, cwd: &str) -> Decision {
                 deny_reasons
                     .push("--ipc=host is not allowed (exposes host IPC namespace)".to_string());
             }
+            DangerousFlag::NetworkContainer(name) => {
+                deny_reasons.push(format!(
+                    "--network=container:{} is not allowed (shares network namespace with another container)",
+                    name
+                ));
+            }
+            DangerousFlag::PidContainer(name) => {
+                deny_reasons.push(format!(
+                    "--pid=container:{} is not allowed (shares process namespace with another container)",
+                    name
+                ));
+            }
+            DangerousFlag::IpcContainer(name) => {
+                deny_reasons.push(format!(
+                    "--ipc=container:{} is not allowed (shares IPC namespace with another container)",
+                    name
+                ));
+            }
+            DangerousFlag::MountPropagation(mode) => {
+                deny_reasons.push(format!(
+                    "bind-propagation={} is not allowed (mount changes propagate to the host)",
+                    mode
+                ));
+            }
         }
     }
 
@@ -157,6 +181,24 @@ pub fn evaluate(cmd: &DockerCommand, config: &Config, cwd: &str) -> Decision {
                 deny_reasons.push(
                     "Compose: 'ipc: host' is not allowed (exposes host IPC namespace)".to_string(),
                 );
+            }
+            DangerousFlag::NetworkContainer(name) => {
+                deny_reasons.push(format!(
+                    "Compose: 'network_mode: container:{}' is not allowed (shares network namespace with another container)",
+                    name
+                ));
+            }
+            DangerousFlag::PidContainer(name) => {
+                deny_reasons.push(format!(
+                    "Compose: 'pid: container:{}' is not allowed (shares process namespace with another container)",
+                    name
+                ));
+            }
+            DangerousFlag::IpcContainer(name) => {
+                deny_reasons.push(format!(
+                    "Compose: 'ipc: container:{}' is not allowed (shares IPC namespace with another container)",
+                    name
+                ));
             }
             _ => {}
         }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -336,6 +336,21 @@ fn generate_tips(reason: &str) -> Vec<String> {
                 .to_string(),
         );
     }
+    if reason.contains("--network=container:")
+        || reason.contains("--pid=container:")
+        || reason.contains("--ipc=container:")
+    {
+        tips.push(
+            "Container namespace sharing allows cross-container access and is blocked by default"
+                .to_string(),
+        );
+    }
+    if reason.contains("bind-propagation=") {
+        tips.push(
+            "shared/rshared propagation allows mount changes to reach the host. Use private (default) instead"
+                .to_string(),
+        );
+    }
 
     // Compose 関連
     if reason.contains("Compose:") {


### PR DESCRIPTION
## Summary
- コンテナ間 namespace 共有（`--network/--pid/--ipc=container:NAME`）を検出して deny
- mount propagation（`shared`/`rshared`）を `-v` と `--mount` 両形式で検出して deny
- Compose ファイルの `network_mode: container:X`/`service:X`、`pid: container:X`/`service:X`、`ipc: container:X`/`service:X` を検出
- sensitive_paths のデフォルトに `.terraform`, `.vault-token`, `.config/gh`, `.npmrc`, `.pypirc` を追加
- `docs/ROADMAP.md` を新規作成（長期タスク管理）

## Changes

### docker_args.rs
- `DangerousFlag` に `NetworkContainer`, `PidContainer`, `IpcContainer`, `MountPropagation` variant を追加
- `--pid`, `--network`, `--ipc` パースを拡張（`container:NAME` 検出、値の確実な消費）
- `parse_volume_flag()` と `parse_mount_flag()` に propagation 検出を追加
- 20個の新規ユニットテスト

### policy.rs
- 新しい `DangerousFlag` variant に対する deny 理由メッセージを追加（CLI + Compose 両方）

### compose.rs
- `network_mode`, `pid`, `ipc` で `container:` と `service:` プレフィックスを検出

### config.rs
- `default_sensitive_paths()` に 5 つの新しいパスを追加

### wrapper.rs
- `generate_tips()` に container namespace と mount propagation のヒントを追加

## Test plan
- [x] 379 テストパス（+23 new: 16 unit + 7 security integration）
- [x] `cargo clippy -- -D warnings` パス
- [x] `cargo fmt --check` パス
- [ ] CI 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)