### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe-docker"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-docker"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 description = "Safe Docker command wrapper and Claude Code hook for container security"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- バージョンを 0.3.0 → 0.4.0 に更新

## v0.4.0 の変更内容
- GitHub Artifact Attestations (Sigstore ベース署名) を導入 (#13)
- SHA256 チェックサムファイルをリリースに同梱
- コンテナ間 namespace 共有検出 (`--network/--pid/--ipc=container:NAME`) (#14)
- mount propagation 検出 (`shared`/`rshared` → deny) (#14)
- Compose の `container:`/`service:` namespace 参照検出 (#14)
- sensitive_paths デフォルト拡充 (#14)
- docs/SUPPLY_CHAIN_SECURITY.md, docs/ROADMAP.md 追加

## Test plan
- [ ] CI パス確認
- [ ] マージ後に `git tag v0.4.0` → リリースワークフローで Artifact Attestations 生成を実地確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)