### PR TITLE
Detect secret build-args, BuildKit paths, and Compose include

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -76,6 +76,10 @@ Docker デーモンの認可プラグイン。全 Docker クライアントに�
 | **`--sysctl net.*`** | **検出済み (v0.5.0)** | ネットワーク設定変更 → ask |
 | **`--add-host` メタデータ IP** | **検出済み (v0.5.0)** | 169.254.169.254 / fd00:ec2::254 → ask |
 | **`--security-opt label=disable`** | **検出済み (v0.5.0)** | SELinux ラベリング無効化（CIS 5.2） → deny |
+| **`--build-arg SECRET/PASSWORD/TOKEN`** | **検出済み (v0.5.0)** | ビルド引数に機密情報パターン → ask |
+| **`--secret src=PATH`** | **検出済み (v0.5.0)** | BuildKit secret ソースパスの $HOME 外アクセス → deny |
+| **`--ssh src=PATH`** | **検出済み (v0.5.0)** | BuildKit SSH ソースパスの $HOME 外アクセス → deny |
+| **Compose `include:`** | **検出済み (v0.5.0)** | 外部ファイル参照の $HOME 外パス → ask |
 
 > 詳細: [docs/ATTACK_SURFACE_ANALYSIS.md](docs/ATTACK_SURFACE_ANALYSIS.md)
 
@@ -126,6 +130,9 @@ Docker デーモンの認可プラグイン。全 Docker クライアントに�
 | `--sysctl kernel.*` | deny | カーネルパラメータ操作 |
 | `--sysctl net.*` | ask | ネットワーク設定変更 |
 | `--add-host HOST:169.254.169.254` | ask | クラウドメタデータエンドポイント |
+| `--build-arg KEY=VALUE` | ask | KEY に SECRET/PASSWORD/TOKEN 等のパターンを含む場合 |
+| `--secret id=...,src=PATH` | パス検証 | BuildKit secret ソースパスの検証 |
+| `--ssh id=...,src=PATH` | パス検証 | BuildKit SSH ソースパスの検証 |
 
 ### バインドマウント
 
@@ -178,6 +185,7 @@ Docker デーモンの認可プラグイン。全 Docker クライアントに�
 | `devices: [/dev/...]` | deny |
 | `sysctls: kernel.*` | deny |
 | `sysctls: net.*` | ask |
+| `include:` (外部ファイル参照) | ask ($HOME 外パス) |
 
 ## 脆弱性報告
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -79,10 +79,10 @@
 - [x] Compose `sysctls:` の対応（リスト形式・マッピング形式の両方）
 - [x] CIS 5.2 対応: `--security-opt label=disable` / `label:disable` 検出
 
-### Phase 5e: ビルド時の安全性（中優先度）
-- [ ] `docker build --build-arg` の機密情報パターン検出（`SECRET`, `PASSWORD`, `TOKEN`, `KEY` → ask）
-- [ ] BuildKit `--secret` / `--ssh` フラグの検証
-- [ ] Compose `include:` ディレクティブ（外部ファイル参照）の対応
+### Phase 5e: ビルド時の安全性 ✅
+- [x] `docker build --build-arg` の機密情報パターン検出（`SECRET`, `PASSWORD`, `TOKEN`, `KEY` → ask）
+- [x] BuildKit `--secret` / `--ssh` フラグの検証（ソースパスの $HOME 外アクセス → deny）
+- [x] Compose `include:` ディレクティブ（外部ファイル参照）の対応（$HOME 外 → ask）
 
 ### 機能: ask レベル化
 - [ ] ask に deep/minor のレベルを導入

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -370,6 +370,18 @@ fn generate_tips(reason: &str) -> Vec<String> {
                 .to_string(),
         );
     }
+    if reason.contains("--build-arg") && reason.contains("secret") {
+        tips.push(
+            "Build args are stored in image layers and visible via 'docker history'. Use BuildKit --secret for sensitive values"
+                .to_string(),
+        );
+    }
+    if reason.contains("Compose include") {
+        tips.push(
+            "Compose include references external files that may contain dangerous settings. Verify the included file is safe"
+                .to_string(),
+        );
+    }
 
     // Compose 関連
     if reason.contains("Compose:") {


### PR DESCRIPTION
## Summary
- **`--build-arg` 機密情報パターン検出**: KEY に SECRET, PASSWORD, TOKEN, PRIVATE_KEY, API_KEY, CREDENTIAL 等を含む場合 → ask（`docker history` でビルド引数が見える警告）
- **BuildKit `--secret` / `--ssh` パス検証**: `src=` / `source=` で指定されたソースパスを host_paths に追加し、$HOME 外アクセス → deny
- **Compose `include:` ディレクティブ対応**: 文字列リスト・マッピング（`path:` キー）の両形式をパースし、参照先ファイルパスの $HOME 外 → ask
- 487テスト全合格、clippy/fmt チェックパス

## Test plan
- [x] `cargo test` — 487 テスト合格（ユニット 305 + 統合 42 + proptest 6 + セキュリティ 73 + ラッパー 67）
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット適合

🤖 Generated with [Claude Code](https://claude.com/claude-code)