### PR TITLE
Bump version to 0.5.0 and document Phase 5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,8 @@ OS 引数 → wrapper::run()
 - 新しい危険フラグを追加する場合: `DangerousFlag` enum → `parse_docker_args()` で検出 → `policy::evaluate()` で判定
 - 新しいパス検証を追加する場合: `DockerCommand::host_paths` に追加 → policy が自動で検証
 - Compose の危険設定: `extract_service_dangerous_settings()` に追加
+- Compose のホストファイル参照: `extract_service_env_file_paths()` で `env_file_paths` に追加 → policy が deny で検証
+- Compose の外部ファイル参照: `extract_include_paths()` で `host_paths` に追加 → policy が ask で検証
 - **テストは必須**: セキュリティツールなので、すべての修正にテストを付ける
 - **clippy を通す**: `cargo clippy -- -D warnings` が通ること
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe-docker"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "safe-docker"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 description = "Safe Docker command wrapper and Claude Code hook for container security"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/nekoruri/safe-docker"
+readme = "README.md"
+keywords = ["docker", "security", "cli", "container", "hook"]
+categories = ["command-line-utilities", "development-tools"]
 
 [features]
 default = []


### PR DESCRIPTION
## Summary
- **バージョンバンプ**: 0.4.0 → 0.5.0（Phase 5a〜5e の全成果を含むリリース）
- **Cargo.toml メタデータ追加**: `repository`, `readme`, `keywords`, `categories`
- **README.md 更新**: Phase 5 で追加した全検出項目を反映
  - 危険フラグ表: `--uts`, `--sysctl`, `--add-host`, `--env-file`, `--label-file`, `--build-arg`, `--secret`/`--ssh`, `label=disable` を追加
  - Compose 検出表: `network_mode: container:NAME`, `ipc:`, `userns_mode:`, `uts:`, `sysctls:`, `env_file:`, `include:` を追加
  - `blocked_capabilities` デフォルト値: 5 → 10 に更新
- **ROADMAP.md 整理**: Phase 5a〜5e を完了済みセクションに移動、v0.5.0 リリース行追加
- **CLAUDE.md 更新**: Compose `env_file_paths` / `host_paths` の開発ガイド追加

## Test plan
- [x] `cargo test` — 505 テスト合格
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット適合

🤖 Generated with [Claude Code](https://claude.com/claude-code)