### PR TITLE
Add config_source field to audit events

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -109,6 +109,7 @@ pub fn run(args: &[String], config: &Config, config_source: &str) -> i32 {
             None,
             &cwd,
             "wrapper",
+            Some(config_source),
         );
         audit::emit(&event, &config.audit);
     }


### PR DESCRIPTION
## Summary
- 監査イベント (`AuditEvent`) に `config_source` フィールドを追加
- JSONL 出力に `config_source` を記録（`skip_serializing_if` で None 時は省略）
- OTLP 出力に `safe_docker.config_source` 属性を追加
- Hook モード・Wrapper モードの両方で設定ソースを追跡・記録

## Details
問題発生時の調査可能性向上の一環。どの設定ファイルが読み込まれたか（ファイルパス / `(default)` / `(FAILED, using defaults)`）を監査ログに記録することで、設定関連の問題を特定しやすくする。

## Test plan
- [x] 既存テスト全76件パス
- [x] `cargo clippy -- -D warnings` パス
- [x] `cargo fmt -- --check` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)