### PR TITLE
Release v0.7.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ cargo bench
 src/
 ├── main.rs            # エントリポイント、モード判別（Hook/Wrapper）、--check-config
 ├── wrapper.rs         # ラッパーモード（evaluate_docker_args, exec_docker, find_real_docker, handle_ask）
+├── setup.rs           # setup サブコマンド（シンボリックリンク作成、PATH 確認）
 ├── hook.rs            # Hook モード: stdin/stdout の JSON プロトコル、Decision 型
 ├── shell.rs           # シェルコマンドのパース（パイプ/チェイン分割、間接実行検出）※Hook モードのみ
 ├── docker_args.rs     # Docker CLI 引数のパース（サブコマンド、フラグ、マウント）※両モード共通

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe-docker"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-docker"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Safe Docker command wrapper and Claude Code hook for container security"


### PR DESCRIPTION
## Summary
- Bump version from 0.6.0 to 0.7.0
- Document `safe-docker setup` command in README (方法 2: setup コマンド)
- Update directory structure in README and CLAUDE.md (setup.rs, test_utils.rs, opa_consistency_test.rs)

## Changes since v0.6.0
- **PR #27**: OPA Docker AuthZ integration guide + consistency tests
- **PR #28**: Pre-commit hook for cargo fmt
- **PR #29**: TempEnvVar RAII guard for safe env var testing
- **PR #30**: `safe-docker setup` command for wrapper mode setup

## Test plan
- [x] `cargo test` — 76 tests passed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)