### PR TITLE
Detect volumes_from and cgroup_parent in Compose, add CgroupParent flag

### DIFF
--- a/src/docker_args.rs
+++ b/src/docker_args.rs
@@ -79,6 +79,8 @@ pub enum DangerousFlag {
     AddHost(String),
     /// --build-arg KEY=VALUE where KEY looks like a secret
     BuildArgSecret(String),
+    /// --cgroup-parent VALUE (カスタム cgroup 親の指定)
+    CgroupParent(String),
 }
 
 impl std::fmt::Display for DangerousFlag {
@@ -106,6 +108,7 @@ impl std::fmt::Display for DangerousFlag {
             DangerousFlag::Sysctl(val) => write!(f, "--sysctl {}", val),
             DangerousFlag::AddHost(val) => write!(f, "--add-host {}", val),
             DangerousFlag::BuildArgSecret(val) => write!(f, "--build-arg {}", val),
+            DangerousFlag::CgroupParent(val) => write!(f, "--cgroup-parent={}", val),
         }
     }
 }
@@ -553,6 +556,21 @@ pub fn parse_docker_args(args: &[&str]) -> DockerCommand {
             }
         } else if arg == "--cgroupns=host" {
             cmd.dangerous_flags.push(DangerousFlag::CgroupnsHost);
+            i += 1;
+            continue;
+        }
+
+        // --cgroup-parent
+        if arg == "--cgroup-parent" {
+            if i + 1 < args.len() {
+                cmd.dangerous_flags
+                    .push(DangerousFlag::CgroupParent(args[i + 1].to_string()));
+                i += 2;
+                continue;
+            }
+        } else if let Some(val) = arg.strip_prefix("--cgroup-parent=") {
+            cmd.dangerous_flags
+                .push(DangerousFlag::CgroupParent(val.to_string()));
             i += 1;
             continue;
         }


### PR DESCRIPTION
## Summary

- Compose ファイルの `volumes_from` と `cgroup_parent` ディレクティブが検出されておらず、セキュリティチェックをバイパス可能だった問題を修正
- `DangerousFlag::CgroupParent(String)` バリアントを追加し、CLI の `--cgroup-parent` も検出対象に
- Compose policy ステージの `_ => {}` キャッチオールを除去し、全 `DangerousFlag` バリアントを明示的に処理（将来の追加漏れをコンパイルエラーで検出可能に）

### 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/docker_args.rs` | `CgroupParent(String)` バリアント追加 + `--cgroup-parent` 検出 |
| `src/compose.rs` | `volumes_from` / `cgroup_parent` パース追加 |
| `src/policy.rs` | CLI に `CgroupParent` → ask 追加、Compose ステージの `_ => {}` 除去 + `VolumesFrom` (ask) / `CgroupnsHost` (deny) / `CgroupParent` (ask) を明示処理 |
| `tests/security_test.rs` | E2E テスト 4件追加 |

## Test plan

- [x] `cargo test` — 全 353 ユニットテスト + 76 統合テスト通過
- [x] `cargo clippy -- -D warnings` — 警告なし
- [ ] Compose `volumes_from` → ask が E2E で動作確認済み
- [ ] Compose `cgroup_parent` → ask が E2E で動作確認済み
- [ ] CLI `--cgroup-parent` (= / space) → ask が E2E で動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)