### PR TITLE
Release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-03-01
+
 ### Added
 
 - `cargo audit` CI workflow (weekly schedule + push/PR triggers)
@@ -179,7 +181,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TOML configuration file support
 - CI and release automation workflows
 
-[Unreleased]: https://github.com/nekoruri/safe-docker/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/nekoruri/safe-docker/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/nekoruri/safe-docker/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/nekoruri/safe-docker/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/nekoruri/safe-docker/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/nekoruri/safe-docker/compare/v0.5.0...v0.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe-docker"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "criterion",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-docker"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Safe Docker command wrapper and Claude Code hook for container security"


### PR DESCRIPTION
## Summary

- Bump version from v0.8.0 to v0.8.1
- Move `[Unreleased]` CHANGELOG entries to `[0.8.1] - 2026-03-01` section
- Update comparison links

### Changes included in v0.8.1

**Added**
- `cargo audit` CI workflow (weekly schedule + push/PR triggers)
- Dependabot configuration for Cargo and GitHub Actions dependencies with grouping
- Code coverage measurement with `cargo-llvm-cov` and Codecov integration
- `codecov.yml` quality gates (project 90%, patch 80%)
- `musl` static binary added to release targets
- CI, Security Audit, and Codecov badges in README

**Changed**
- Refactor `is_flag_with_value` to table-driven `VALUE_FLAGS` constant with categorized entries
- Add `[lints]` section to `Cargo.toml` for centralized lint management
- Expand `.gitignore` with editor, OS, and screenshot patterns

**Fixed**
- Documentation inconsistencies (DOC-01 through DOC-09)

## Test plan

- [x] `cargo test` — 全 689 テスト合格
- [x] `cargo clippy` — 警告なし
- [ ] CI が全て green であることを確認
- [ ] マージ後に `v0.8.1` タグを作成してリリース

🤖 Generated with [Claude Code](https://claude.com/claude-code)